### PR TITLE
Добавляет новую схему для media

### DIFF
--- a/schemas/1.1/content/chunk/media.json
+++ b/schemas/1.1/content/chunk/media.json
@@ -3,7 +3,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Media.",
     "name": "media-chunk-content",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "A representation objects of multimedia: audio, video, image etc.",
     "type": "object",
     "additionalProperties": false,
@@ -32,13 +32,7 @@
                         "$ref": "https://xshl.org/schemas/1.1/content/chunk/person.json"
                     },
                     {
-                        "$ref": "https://xshl.org/schemas/1.1/definitions/audio.json"
-                    },
-                    {
-                        "$ref": "https://xshl.org/schemas/1.1/definitions/video.json"
-                    },
-                    {
-                        "$ref": "https://xshl.org/schemas/1.1/definitions/image.json"
+                        "$ref": "https://xshl.org/schemas/1.1/definitions/file.json"
                     },
                     {
                         "$ref": "https://xshl.org/schemas/1.1/definitions/text.json"

--- a/schemas/1.1/definitions/file.json
+++ b/schemas/1.1/definitions/file.json
@@ -6,7 +6,7 @@
     "title": "PPMF.",
     "description": "Publish Package File Metadata (PPMF)",
     "type": "object",
-    "required": ["target", "version"],
+    "required": ["target"],
     "properties": {
         "@context": {"$ref": "https://xshl.org/schemas/1.1/definitions/context.json"},
         "@type": {"$ref": "https://xshl.org/schemas/1.1/definitions/type.json"},

--- a/schemas/1.1/definitions/file.json
+++ b/schemas/1.1/definitions/file.json
@@ -2,7 +2,7 @@
     "$id": "https://xshl.org/schemas/1.1/definitions/file.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "name": "file-xshl",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "title": "PPMF.",
     "description": "Publish Package File Metadata (PPMF)",
     "type": "object",
@@ -24,16 +24,6 @@
             "description": "Multipurpose Internet Mail Extensions.",
             "$ref": "https://xshl.org/schemas/1.1/definitions/target.json"
         },
-        "count": {
-            "title": "Counters",
-            "description": "Counters of objects in the composition of the PPMF.",
-            "type": "object",
-            "properties": {
-                "top": {"type": "integer", "minimum": 0},
-                "total": {"type": "integer", "minimum": 0}
-            },
-            "additionalProperties": true
-        },
         "created": {"type": "string", "format": "date-time"},
         "modified": {"type": "string", "format": "date-time"},
         "etag": {
@@ -42,6 +32,7 @@
             "description": "Identifier for a specific version of a resource.",
             "type": "string"
         },
+        "extra": {"type": "object"},
         "pid": {
             "id": "https://datatracker.ietf.org/doc/html/rfc4122",
             "title": "PID",


### PR DESCRIPTION
В связи с тем, что схемы для video, image, audio избыточны, тк по сути описывают файлыв медиа, мы решили изменить схему и внести изменения таким образом, чтобы убрать дублирующие себя схемы и сделать работу с файлами по единому принципу.